### PR TITLE
RedisCacheConnectionPoolManager.EmitConnections: Move logger.LogDebug before loop

### DIFF
--- a/src/core/StackExchange.Redis.Extensions.Core/Implementations/RedisCacheConnectionPoolManager.cs
+++ b/src/core/StackExchange.Redis.Extensions.Core/Implementations/RedisCacheConnectionPoolManager.cs
@@ -149,9 +149,10 @@ namespace StackExchange.Redis.Extensions.Core.Implementations
             if (this.connections.Count >= this.redisConfiguration.PoolSize)
                 return;
 
+            logger.LogDebug("Creating the redis connection pool with {0} connections.", this.redisConfiguration.PoolSize);
+
             for (var i = 0; i < this.redisConfiguration.PoolSize; i++)
             {
-                logger.LogDebug("Creating the redis connection pool with {0} connections.", this.redisConfiguration.PoolSize);
                 this.EmitConnection();
             }
         }


### PR DESCRIPTION
Hi, I think this is just a typo. The EmitConnection has its own logger call.

Before:
```log
[14:06:54 DBG] Creating the redis connection pool with 5 connections.
[14:06:54 DBG] Creating the redis connection pool with 5 connections.
[14:06:54 DBG] Creating the redis connection pool with 5 connections.
[14:06:54 DBG] Creating the redis connection pool with 5 connections.
[14:06:54 DBG] Creating the redis connection pool with 5 connections.
...
[14:07:15 DBG] Creating new Redis connection.
```

After:
```log
[14:06:54 DBG] Creating the redis connection pool with 5 connections.
....
[14:07:15 DBG] Creating new Redis connection.
```